### PR TITLE
Collectd cookbook changes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,7 @@ else
   default['collectd']['service']['package_name'] = 'collectd'
 end
 
-default['collectd']['service']['configuration']['plugin_dir'] = '/usr/lib/collectd'
+default['collectd']['service']['configuration']['plugin_dir'] = '/usr/lib64/collectd'
 default['collectd']['service']['configuration']['types_d_b'] = '/usr/share/collectd/types.db'
 default['collectd']['service']['configuration']['interval'] = 10
 default['collectd']['service']['configuration']['read_threads'] = 5

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,7 @@ else
   default['collectd']['service']['package_name'] = 'collectd'
 end
 
-default['collectd']['service']['configuration']['plugin_dir'] = '/usr/lib64/collectd'
+default['collectd']['service']['configuration']['plugin_dir'] = '/usr/lib/collectd'
 default['collectd']['service']['configuration']['types_d_b'] = '/usr/share/collectd/types.db'
 default['collectd']['service']['configuration']['interval'] = 10
 default['collectd']['service']['configuration']['read_threads'] = 5

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -55,11 +55,12 @@ module CollectdCookbook
           if value.is_a?(Array)
             %(#{tabs}#{key} "#{value.uniq.join('", "')}")
           elsif value.kind_of?(Hash) # rubocop:disable Style/ClassCheck
-            id = value.delete('id')
+            id = value['id']
             next if id.nil?
+            config_hash = value.reject { |k, _| k == 'id' }
             [%(#{tabs}<#{key} "#{id}">),
-              write_elements(value, indent.next),
-              %(#{tabs}</#{key}>)
+             write_elements(config_hash, indent.next),
+             %(#{tabs}</#{key}>)
             ].join("\n")
           elsif value.is_a?(String)
             %(#{tabs}#{key} "#{value}")

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -49,17 +49,16 @@ module CollectdCookbook
       # @return [String]
       def write_elements(directives, indent = 0)
         tabs = ("\t" * indent)
-        directives.map do |key, value|
+        directives.dup.map do |key, value|
           next if value.nil?
           key = snake_to_camel(key)
           if value.is_a?(Array)
             %(#{tabs}#{key} "#{value.uniq.join('", "')}")
           elsif value.kind_of?(Hash) # rubocop:disable Style/ClassCheck
-            id = value['id']
+            id = value.delete('id')
             next if id.nil?
-            config_hash = value.reject { |k, _| k == 'id' }
             [%(#{tabs}<#{key} "#{id}">),
-             write_elements(config_hash, indent.next),
+             write_elements(value, indent.next),
              %(#{tabs}</#{key}>)
             ].join("\n")
           elsif value.is_a?(String)

--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -61,6 +61,10 @@ module CollectdCookbook
       # @!attribute package_source
       # @return [String]
       attribute(:package_source, kind_of: String)
+	      
+      # @!attribute command
+      # @return [String]
+      attribute(:command, kind_of: String, default: '/usr/sbin/collectd -C /etc/collectd.conf -f')
     end
   end
 
@@ -122,7 +126,7 @@ module CollectdCookbook
       # Sets the tuning options for service management with {PoiseService::ServiceMixin}.
       # @param [PoiseService::Service] service
       def service_options(service)
-        service.command("/usr/sbin/collectd -C #{new_resource.config_filename} -f")
+        service.command(new_resource.command)
         service.directory(new_resource.directory)
         service.user(new_resource.user)
         service.environment('PATH' => '/usr/local/bin:/usr/bin:/bin')

--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -64,7 +64,7 @@ module CollectdCookbook
 
       # @!attribute command
       # @return [String]
-      attribute(:command, kind_of: String, default: '/usr/sbin/collectd -C /etc/collectd.conf -f')
+      attribute(:command, kind_of: String, default: lazy { "/usr/sbin/collectd -C #{config_filename} -f" })
     end
   end
 

--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -61,7 +61,7 @@ module CollectdCookbook
       # @!attribute package_source
       # @return [String]
       attribute(:package_source, kind_of: String)
-	      
+
       # @!attribute command
       # @return [String]
       attribute(:command, kind_of: String, default: '/usr/sbin/collectd -C /etc/collectd.conf -f')


### PR DESCRIPTION
1. On ubuntu, /usr/lib/collectd is where the plugins are installed by default on 64 bit architecture
2. Collectd does a chdir to collectd directory '/var/lib/collectd' and hence needs executable permissions on the directory
3. Support different command for collectd service as omnibus collectd package has a different start command
4. Don't remove attributes from hash in helpers.rb. Attributes are merged at this point and chef considers them read only