### PR TITLE
Use standard solaris provider

### DIFF
--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -68,18 +68,9 @@ module CollectdCookbook
       # @return [String]
       attribute(:environment, kind_of: Hash, default: { 'PATH' => '/usr/bin:/bin:/usr/sbin:/sbin' })
 
-      # @!attribute solaris_admin_file
-      # @return [String]
-      attribute(:solaris_admin_file, kind_of: String, default: lazy { default_solaris_admin_file })
-
       # @return [String]
       def default_command
         "/usr/sbin/collectd -C #{config_filename} -f"
-      end
-
-      # @return [String]
-      def default_solaris_admin_file
-        ::File.join(Chef::Config[:file_cache_path], 'default')
       end
     end
   end
@@ -104,22 +95,11 @@ module CollectdCookbook
                            end.path
                          end
 
-          # create admin file for solaris package
-          ruby_block 'create solaris admin file' do
-            block do
-              if platform?('solaris2')
-                text = ::File.read('/var/sadm/install/admin/default')
-                ::File.write(new_resource.solaris_admin_file, text.gsub(/ask/, 'nocheck'))
-              end
-            end
-          end
-
           package new_resource.package_name do
             provider Chef::Provider::Package::Dpkg if platform?('ubuntu')
-            # solaris provider only supports install action and needs admin file
+            # solaris provider only supports install action
             if platform?('solaris2')
               provider Chef::Provider::Package::Solaris
-              options "-a #{new_resource.solaris_admin_file}"
               action :install
             else
               action :upgrade

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'noah@coderanger.net'
 license 'Apache 2.0'
 description 'Installs and configures the collectd monitoring daemon.'
 long_description 'Installs and configures the collectd monitoring daemon.'
-version '2.0.5'
+version '2.0.6'
 
 supports 'ubuntu', '>= 10.04'
 supports 'centos', '>= 5.8'


### PR DESCRIPTION
Go back to using standard solaris provider, now that we override in our internal cookbook blp-base
cc @johnbellone 