### PR TITLE
Fix multi value config

### DIFF
--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -53,7 +53,13 @@ module CollectdCookbook
           next if value.nil?
           key = snake_to_camel(key)
           if value.is_a?(Array)
-            value.each{ |val| %(#{tabs}#{key} "#{val}") }
+            value.map do |val|
+              if val.is_a?(String)
+                %(#{tabs}#{key} "#{val}")
+              else
+                %(#{tabs}#{key} #{val})
+              end
+            end.join("\n")
           elsif value.kind_of?(Hash) # rubocop:disable Style/ClassCheck
             id = value.delete('id')
             next if id.nil?

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -53,7 +53,7 @@ module CollectdCookbook
           next if value.nil?
           key = snake_to_camel(key)
           if value.is_a?(Array)
-            %(#{tabs}#{key} "#{value.uniq.join('", "')}")
+            value.each{ |val| %(#{tabs}#{key} "#{val}") }
           elsif value.kind_of?(Hash) # rubocop:disable Style/ClassCheck
             id = value.delete('id')
             next if id.nil?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'noah@coderanger.net'
 license 'Apache 2.0'
 description 'Installs and configures the collectd monitoring daemon.'
 long_description 'Installs and configures the collectd monitoring daemon.'
-version '2.1.1'
+version '2.1.2'
 
 supports 'ubuntu', '>= 10.04'
 supports 'centos', '>= 5.8'


### PR DESCRIPTION
Multi valued config need to be in separate line instead of comma separated string. For example df plugin has two multi valued attributes (FSType and MountPoint):

```
<Plugin "df">
        ReportReserved false
        IgnoreSelected true
        FSType "proc", "sysfs", "fusectl", "debugfs", "securityfs", "devtmpfs", "devpts", "tmpfs", "nfs"
        ReportInodes true
        ValuesPercentage true
        MountPoint "/proc", "/dev", "/zones"
</Plugin>
```
but it should be like this:
```
LoadPlugin "df"
<Plugin "df">
        ReportReserved false
        IgnoreSelected true
        FSType "proc"
        FSType "sysfs"
        FSType "fusectl"
        FSType "debugfs"
        FSType "securityfs"
        FSType "devtmpfs"
        FSType "devpts"
        FSType "tmpfs"
        FSType "nfs"
        ReportInodes true
        ValuesPercentage true
        MountPoint "/proc"
        MountPoint "/dev"
        MountPoint "/zones"
</Plugin>
```